### PR TITLE
Fix Build due to Rust update

### DIFF
--- a/src/rest_api_lib/Cargo.toml
+++ b/src/rest_api_lib/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
 utoipa = { version = "4.2.3", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "7.1.0", features = ["axum"] }
 zerofrom = "=0.1.5"
+litemap = "=0.7.4"
 
 [lib]
 name = "jrtc_rest_api_lib"


### PR DESCRIPTION


```
Error: package zerofrom v0.1.6 cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.75.0

Either upgrade to rustc 1.81 or newer, or use

cargo update zerofrom@0.1.6 --precise ver

where ver is the latest version of zerofrom supporting rustc 1.75.0
```