### PR TITLE
Fix pipeline failure at main due to test log conflict, and set explict exit code and small tweaks

### DIFF
--- a/pipeline/standard-tests.yaml
+++ b/pipeline/standard-tests.yaml
@@ -36,9 +36,8 @@ steps:
       echo Building: jbpf, jrtc, jbpf codelets, jbpf IPC agent, and JRTC app
       echo And Running JRTC Tests
       JRTC_TESTS_OUTPUT=/tmp/jrtc_tests_output.log
-      rm -rf $JRTC_TESTS_OUTPUT || true
 
-      docker run --init --privileged \
+      if ! docker run --init --privileged \
         --ulimit memlock=-1 \
         --network host \
         --cap-add=SYS_ADMIN \
@@ -46,18 +45,14 @@ steps:
         --mount type=tmpfs,destination=/dev/shm \
         -e VERBOSE=1 \
         -e JRTC_PATH=/jrtc \
-        -v /tmp:/tmp \
+        -v $JRTC_TESTS_OUTPUT:/tmp/jrtc_tests_output.log \
         ${{parameters.testCase['sanitizerBuildParam']}} \
         --entrypoint=/jrtc/helper_build_files/run_all_integration_tests.sh \
-        $(containerRegistry)/jrtc-${{ parameters.dockerType }}:$(imageTag) \
-        |& tee $JRTC_TESTS_OUTPUT
-
-      exit_code=${PIPESTATUS[0]}  # Capture docker run exit code
-      if [[ $exit_code -ne 0 ]]; then
-          echo "Error Running JRTC Tests at /jrtc/sample_apps/"
-          exit 1
+        $(containerRegistry)/jrtc-${{ parameters.dockerType }}:$(imageTag); then
+        echo Error running JRTC tests
+        exit 1
       fi
-      
+
       echo ".............................................Output.log: $TEST ............................................."
       cat $JRTC_TESTS_OUTPUT
       

--- a/pipeline/standard-tests.yaml
+++ b/pipeline/standard-tests.yaml
@@ -32,7 +32,7 @@ steps:
     continueOnError: false
 
   - bash: |
-      set -e
+      set -ex
       echo Building: jbpf, jrtc, jbpf codelets, jbpf IPC agent, and JRTC app
       echo And Running JRTC Tests
       JRTC_TESTS_OUTPUT=/tmp/jrtc_tests_output.log

--- a/pipeline/standard-tests.yaml
+++ b/pipeline/standard-tests.yaml
@@ -32,7 +32,6 @@ steps:
     continueOnError: false
 
   - bash: |
-      set -ex
       echo Building: jbpf, jrtc, jbpf codelets, jbpf IPC agent, and JRTC app
       echo And Running JRTC Tests
       JRTC_TESTS_OUTPUT=/tmp/jrtc_tests_output.log
@@ -52,12 +51,17 @@ steps:
         echo Error running JRTC tests
         exit 1
       fi
-
-      echo ".............................................Output.log: $TEST ............................................."
-      cat $JRTC_TESTS_OUTPUT
       
-      ## Copy to artifacts
-      cp $JRTC_TESTS_OUTPUT $(Build.ArtifactStagingDirectory)/sample_tests_output_${{ parameters.testCase.id }}_${{ parameters.dockerType }}.log      
+      if [ -f $JRTC_TESTS_OUTPUT ]; then
+        echo ".............................................Output.log: $JRTC_TESTS_OUTPUT ............................................."
+        cat $JRTC_TESTS_OUTPUT
+
+        ## Copy to artifacts
+        cp $JRTC_TESTS_OUTPUT $(Build.ArtifactStagingDirectory)/sample_tests_output_${{ parameters.testCase.id }}_${{ parameters.dockerType }}.log
+      else
+        echo "WARNING: $JRTC_TESTS_OUTPUT does not exist. Skipping log copy." >&2
+        echo "##vso[task.logissue type=warning]$JRTC_TESTS_OUTPUT does not exist. Skipping log copy."
+      fi
 
     displayName: Integration Tests sample apps
     continueOnError: false


### PR DESCRIPTION
## Background
The pipeline [on main is failing](https://belgrade.visualstudio.com/jrt-controller/_build/results?buildId=21399&view=results) - because the exit code is not zero despite the tests passing with "All tests passed!" in [here](https://github.com/microsoft/jrt-controller/blob/main/helper_build_files/run_all_integration_tests.sh#L33)

The [set -e](https://github.com/microsoft/jrt-controller/blob/main/pipeline/standard-tests.yaml#L35) failed [here](https://github.com/microsoft/jrt-controller/blob/main/pipeline/standard-tests.yaml#L62) when the $JRTC_TESTS_OUTPUT is missing.

## Why it failed?
![image](https://github.com/user-attachments/assets/a2f6edf5-1950-44d8-b3e6-0a001daf87b2)

There is a potential conflict when both:
- docker run (via tee) writes to [$JRTC_TESTS_OUTPUT](https://github.com/microsoft/jrt-controller/blob/main/helper_build_files/run_all_integration_tests.sh#L20).
- The script inside the container (run_all_integration_tests.sh) also writes to the same [$JRTC_TESTS_OUTPUT file](https://github.com/microsoft/jrt-controller/blob/main/helper_build_files/run_all_integration_tests.sh#L20)

tee $JRTC_TESTS_OUTPUT captures the entire output of docker run and writes to both stdout and the file.
If [run_all_integration_tests.sh](https://github.com/microsoft/jrt-controller/blob/main/helper_build_files/run_all_integration_tests.sh) inside the container also writes to $JRTC_TESTS_OUTPUT, two processes are writing to the same file at the same time.

This can lead to:
- Corrupted output (mixed-up logs).
- Race conditions (one process overwriting the other's writes).
- Unexpected behavior (e.g., missing logs) - in this case causing the pipeline to fail with "set -e"

## Changes in this PR
- refactor and set explicit "exit 0" in [run_all_integration_tests.sh](https://github.com/microsoft/jrt-controller/blob/main/helper_build_files/run_all_integration_tests.sh)
- fixes the pipeline by removing the `tee` command in pipeline `docker run` as the tests will be redirected to stdout anyway.
- raises a pipeline warning if the $JRTC_TESTS_OUTPUT can't be copied.