### PR TITLE
Fix pipeline problems completely

### DIFF
--- a/helper_build_files/run_all_integration_tests.sh
+++ b/helper_build_files/run_all_integration_tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-set -ex
 
 if [ -z "$JRTC_PATH" ]; then
     echo "Error: JRTC_PATH environment variable is not set. Please set it before running this script."
@@ -10,7 +9,7 @@ fi
 
 if ! pushd "$JRTC_PATH/helper_build_files"; then
     echo "Error: Failed to change directory to $JRTC_PATH/helper_build_files"
-    exit 1
+    exit 2
 fi
 
 TEST_CASES=("first_example" "first_example_c" "first_example_py" "advanced_example" "advanced_example_c")
@@ -23,7 +22,7 @@ for TEST in "${TEST_CASES[@]}"; do
     "$JRTC_PATH/helper_build_files/integration_tests.sh" "$TEST" |& tee "$JRTC_TESTS_OUTPUT"
     if [ "${PIPESTATUS[0]}" -ne 0 ]; then
         echo "Error: Test script failed for $TEST"
-        exit 1
+        exit 3
     fi
   
     echo ".............................................Output.log: $TEST ............................................."
@@ -31,7 +30,7 @@ for TEST in "${TEST_CASES[@]}"; do
 
     if ! "$JRTC_PATH/sample_apps/$TEST/assert.sh" "$JRTC_TESTS_OUTPUT" "$TEST"; then
         echo "Test Assertion failed for $TEST"
-        exit 1
+        exit 4
     fi
         
     echo ".......................................................................................... Test Passed: $TEST .........................................................................................."

--- a/helper_build_files/run_all_integration_tests.sh
+++ b/helper_build_files/run_all_integration_tests.sh
@@ -18,6 +18,7 @@ JRTC_TESTS_OUTPUT=/tmp/jrtc_tests_output.log
 for TEST in "${TEST_CASES[@]}"; do
     echo ".......................................................................................... Running test: $TEST .........................................................................................."
     rm -rf "$JRTC_TESTS_OUTPUT" || true
+    touch "$JRTC_TESTS_OUTPUT" || { echo "Error: Failed to create $JRTC_TESTS_OUTPUT"; exit 2; }
 
     "$JRTC_PATH/helper_build_files/integration_tests.sh" "$TEST" |& tee "$JRTC_TESTS_OUTPUT"
     if [ "${PIPESTATUS[0]}" -ne 0 ]; then
@@ -26,6 +27,7 @@ for TEST in "${TEST_CASES[@]}"; do
     fi
   
     echo ".............................................Output.log: $TEST ............................................."
+    timeout 10 tail -f "$JRTC_TESTS_OUTPUT" | grep -q .  # Wait until file is non-empty
     cat "$JRTC_TESTS_OUTPUT"
 
     if ! "$JRTC_PATH/sample_apps/$TEST/assert.sh" "$JRTC_TESTS_OUTPUT" "$TEST"; then

--- a/pipeline/standard-tests.yaml
+++ b/pipeline/standard-tests.yaml
@@ -23,6 +23,7 @@ steps:
         --shm-size=1g \
         --mount type=tmpfs,destination=/dev/shm \
         -e VERBOSE=1 \
+        -e RUN_TESTS=1 \
         -e JRTC_PATH=/jrtc \
         $(containerRegistry)/jrtc-${{ parameters.dockerType }}:$(imageTag); then
         echo Error building and testing

--- a/pipeline/standard-tests.yaml
+++ b/pipeline/standard-tests.yaml
@@ -36,6 +36,8 @@ steps:
       echo Building: jbpf, jrtc, jbpf codelets, jbpf IPC agent, and JRTC app
       echo And Running JRTC Tests
       JRTC_TESTS_OUTPUT=/tmp/jrtc_tests_output.log
+      rm -f $JRTC_TESTS_OUTPUT || true
+      touch $JRTC_TESTS_OUTPUT
 
       if ! docker run --init --privileged \
         --ulimit memlock=-1 \
@@ -45,7 +47,7 @@ steps:
         --mount type=tmpfs,destination=/dev/shm \
         -e VERBOSE=1 \
         -e JRTC_PATH=/jrtc \
-        -v $JRTC_TESTS_OUTPUT:/tmp/jrtc_tests_output.log \
+        -v /tmp:/tmp \
         ${{parameters.testCase['sanitizerBuildParam']}} \
         --entrypoint=/jrtc/helper_build_files/run_all_integration_tests.sh \
         $(containerRegistry)/jrtc-${{ parameters.dockerType }}:$(imageTag); then


### PR DESCRIPTION
This PR:
1. re-enables the C tests as they were turned off by mistakes in [here](https://github.com/microsoft/jrt-controller/pull/23)
2. sets different exit code so that we understand better the failure.
3. wait for the log file to be created (non empty) - as this may fail the pipeline if the log file is not created in time.
4. the `$JRTC_TESTS_OUTPUT` is incorrectly mapped if the file does not exist, the docker will treat it as directory instead.

https://github.com/microsoft/jrt-controller/issues/29