### PR TITLE
Configure Port of RESTful Server for JRTC

### DIFF
--- a/jrtc_tests/test_data/yaml/valid.yaml
+++ b/jrtc_tests/test_data/yaml/valid.yaml
@@ -3,6 +3,7 @@ jbpf_io_config:
   jbpf_path: "/var/run/jrtc"
 jrtc_router_config:
   ipc_name: "aaaaa"
+  port: 1234
   thread_config:
     affinity_mask: 3
     has_sched_config: true

--- a/jrtc_tests/unit_tests/yaml_test.c
+++ b/jrtc_tests/unit_tests/yaml_test.c
@@ -53,6 +53,7 @@ test_yaml_parsing()
         assert(strcmp(config.jbpf_io_config.jbpf_namespace, "jrtc") == 0);
         assert(strcmp(config.jbpf_io_config.jbpf_path, "/var/run/jrtc") == 0);
         assert(strcmp(config.jrtc_router_config.io_config.ipc_name, "aaaaa") == 0);
+        assert(config.port == 1234);
         assert(
             strcmp(
                 config.jbpf_io_config.ipc_config.addr.jbpf_io_ipc_name, config.jrtc_router_config.io_config.ipc_name) ==
@@ -78,6 +79,7 @@ test_yaml_parsing()
         assert(strcmp(config.jbpf_io_config.jbpf_namespace, "jbpf") == 0);
         assert(strcmp(config.jbpf_io_config.jbpf_path, "/tmp") == 0);
         assert(strcmp(config.jrtc_router_config.io_config.ipc_name, DEFAULT_JRTC_NAME) == 0);
+        assert(config.port == DEFAULT_PORT);
         assert(
             strcmp(
                 config.jbpf_io_config.ipc_config.addr.jbpf_io_ipc_name, config.jrtc_router_config.io_config.ipc_name) ==
@@ -100,6 +102,7 @@ test_yaml_parsing()
         assert(config.jrtc_router_config.thread_config.sched_config.sched_runtime == 10000000);
         assert(config.jrtc_router_config.thread_config.sched_config.sched_period == 30000000);
         assert(config.jrtc_router_config.thread_config.sched_config.sched_priority == 99);
+        assert(config.port == DEFAULT_PORT);
         assert(strcmp(config.jbpf_io_config.jbpf_namespace, "jbpf") == 0);
         assert(strcmp(config.jbpf_io_config.jbpf_path, "/tmp") == 0);
         assert(strcmp(config.jrtc_router_config.io_config.ipc_name, DEFAULT_JRTC_NAME) == 0);
@@ -129,6 +132,7 @@ test_yaml_parsing()
         assert(config.jrtc_router_config.thread_config.sched_config.sched_period == 30000000);
         assert(config.jrtc_router_config.thread_config.sched_config.sched_priority == 99);
         assert(strcmp(config.jbpf_io_config.jbpf_path, "/tmp") == 0);
+        assert(config.port == DEFAULT_PORT);
         assert(strcmp(config.jrtc_router_config.io_config.ipc_name, DEFAULT_JRTC_NAME) == 0);
         assert(
             strcmp(
@@ -157,6 +161,7 @@ test_yaml_parsing()
         assert(config.jrtc_router_config.thread_config.sched_config.sched_period == 30000000);
         assert(config.jrtc_router_config.thread_config.sched_config.sched_priority == 99);
         assert(strcmp(config.jbpf_io_config.jbpf_path, "/tmp") == 0);
+        assert(config.port == DEFAULT_PORT);
         assert(strcmp(config.jrtc_router_config.io_config.ipc_name, DEFAULT_JRTC_NAME) == 0);
         assert(
             strcmp(

--- a/src/controller/jrtc_config.c
+++ b/src/controller/jrtc_config.c
@@ -92,6 +92,8 @@ init_jrtc_config(jrtc_config_t* config)
     config->jrtc_router_config.io_config.ipc_name[JBPF_IO_IPC_MAX_NAMELEN - 1] = '\0';
     strncpy(config->jbpf_io_config.ipc_config.addr.jbpf_io_ipc_name, DEFAULT_JRTC_NAME, JBPF_IO_IPC_MAX_NAMELEN - 1);
     config->jbpf_io_config.ipc_config.addr.jbpf_io_ipc_name[JBPF_IO_IPC_MAX_NAMELEN - 1] = '\0';
+
+    config->port = DEFAULT_PORT;
 }
 
 int
@@ -186,6 +188,8 @@ set_config_values(const char* filename, jrtc_config_t* config)
                             config->jbpf_io_config.ipc_config.addr.jbpf_io_ipc_name,
                             expanded_value,
                             sizeof(config->jbpf_io_config.ipc_config.addr.jbpf_io_ipc_name) - 1);
+                    } else if (strcmp(key, "port") == 0) {
+                        config->port = atoi(expanded_value);
                     }
                 }
 

--- a/src/controller/jrtc_config.h
+++ b/src/controller/jrtc_config.h
@@ -6,6 +6,7 @@
 #include "jrtc_config_int.h"
 
 #define DEFAULT_JRTC_NAME "jrt_controller"
+#define DEFAULT_PORT 3001
 
 /**
  * @brief Expands environment variables in a given string (e.g., "Path: ${HOME}/test")

--- a/src/controller/jrtc_config_int.h
+++ b/src/controller/jrtc_config_int.h
@@ -10,6 +10,7 @@ struct jrtc_config
 {
     struct jrtc_router_config jrtc_router_config;
     struct jbpf_io_config jbpf_io_config;
+    int port;
 };
 
 typedef struct jrtc_config jrtc_config_t;

--- a/src/controller/jrtc_int.c
+++ b/src/controller/jrtc_int.c
@@ -378,12 +378,15 @@ ctrlc_handler(int signo)
     }
 }
 
+typedef struct _rest_server_args
+{
+    void* args;
+    unsigned int port;
+} rest_server_args_t;
+
 void*
 _start_rest_server(void* args)
 {
-
-    unsigned int port = 3001;
-
     if (pthread_setname_np(pthread_self(), "jrtc_rest")) {
         jrtc_logger(JRTC_CRITICAL, "Error in setting app name to %s\n", "jrtc_rest");
     } else {
@@ -394,7 +397,9 @@ _start_rest_server(void* args)
     callbacks.load_app = load_app;
     callbacks.unload_app = unload_app;
 
-    jrtc_start_rest_server(args, port, &callbacks);
+    rest_server_args_t* rest_server_args = (rest_server_args_t*)args;
+    jrtc_logger(JRTC_INFO, "Starting REST server on port %d\n", rest_server_args->port);
+    jrtc_start_rest_server(rest_server_args->args, rest_server_args->port, &callbacks);
 
     return NULL;
 }
@@ -414,15 +419,26 @@ start_jrtc(const char* config_file)
 
     sem_init(&jrtc_stop, 0, 0);
 
-    rest_server_handle = jrtc_create_rest_server();
-    pthread_create(&rest_server, NULL, _start_rest_server, rest_server_handle);
-
     jrtc_config_t jrtc_config = {0};
     res = set_config_values(config_file, &jrtc_config);
     if (res != 0) {
         jrtc_logger(JRTC_ERROR, "Failed to read thread config from YAML file: %s (%d)\n", config_file, res);
         return -2;
     }
+    rest_server_handle = jrtc_create_rest_server();
+    if (rest_server_handle == NULL) {
+        jrtc_logger(JRTC_CRITICAL, "Failed to create rest server\n");
+        return -1;
+    }
+    rest_server_args_t* rest_server_handle_args = malloc(sizeof(rest_server_args_t));
+    if (rest_server_handle_args == NULL) {
+        jrtc_logger(JRTC_CRITICAL, "Failed to allocate memory for rest server args\n");
+        return -1;
+    }
+    rest_server_handle_args->args = rest_server_handle;
+    rest_server_handle_args->port = jrtc_config.port;
+    pthread_create(&rest_server, NULL, _start_rest_server, (void*)rest_server_handle_args);
+
     res = jrtc_router_init(&jrtc_config);
 
     if (res < 0) {
@@ -471,6 +487,7 @@ start_jrtc(const char* config_file)
     jrtc_logger(JRTC_INFO, "jrt-controller stopped.\n");
 
     sem_destroy(&jrtc_stop);
+    free(rest_server_handle_args);
     return res;
 }
 

--- a/src/rest_api_lib/src/lib.rs
+++ b/src/rest_api_lib/src/lib.rs
@@ -440,7 +440,7 @@ pub extern "C" fn jrtc_stop_rest_server(ptr: *mut c_void) {
 
 #[no_mangle]
 pub extern "C" fn jrtc_start_rest_server(ptr: *mut c_void, port: u16, cbs: *mut Callbacks) {
-    println!("Starting REST server");
+    println!("Starting REST server at port {}", port);
 
     // Check for null pointers and handle errors
     if ptr.is_null() || cbs.is_null() {


### PR DESCRIPTION
This PR allows to configure the port number (default is 3001) for jrtc through the config.yaml

```yaml
jrtc_router_config:
  port: 3001
```

See: https://github.com/microsoft/jrt-controller/issues/34

