### PR TITLE
Fix assigning -1 to size_t -> Invalid Argument

### DIFF
--- a/src/controller/jrtc_north_io_app.c
+++ b/src/controller/jrtc_north_io_app.c
@@ -244,7 +244,7 @@ aa_channel_encode_fwd_out_data(
 
         msg_size = jrtc_router_create_serialized_msg(data_entries[i], data_to_write, AA_NET_ELEM_SIZE);
 
-        if (msg_size) {
+        if (msg_size > 0) {
             iovec[n_sent][0].iov_base = data_to_write;
             iovec[n_sent][0].iov_len = msg_size;
             jmbuf_list[n_sent] = jmbuf;
@@ -254,7 +254,7 @@ aa_channel_encode_fwd_out_data(
             datagrams[n_sent].msg_hdr.msg_namelen = sizeof(struct sockaddr_in);
             n_sent++;
         } else {
-            jrtc_logger(JRTC_ERROR, "Encoding failed\n");
+            jrtc_logger(JRTC_ERROR, "Encoding failed with msg_size %d\n", msg_size);
             jbpf_mbuf_free(jmbuf, false);
         }
         jrtc_router_channel_release_buf(data_entries[i].data);


### PR DESCRIPTION
Invalid Argument Error is misleading as we are assigning "-1" to a size_t. ```iovec[n_sent][0].iov_len = msg_size;```

```
2025-06-17T12:37:12.879315+00:00 : {"timestamp": 1750163832776168192, "stream_index": "MAC_SCHED_PHR_STATS", "stats": [{"ueid": null, "ue_ctx": null, "serv_cell_id": 0, "ph_min": 0, "ph_max": 4294967295, "p_cmax_min": 19, "p_cmax_max": 20, "du_ue_index": 0}]}
[ERROR:/jrtc/src/controller/jrtc_north_io_app.c:aa_channel_encode_fwd_out_data:267] [ERROR]: Error sending all output messages. Had to send 5, but sent 2
[ERROR:/jrtc/src/controller/jrtc_north_io_app.c:aa_channel_encode_fwd_out_data:268] [ERROR]: Error: Invalid argument
[ERROR:/jrtc/src/controller/jrtc_north_io_app.c:aa_channel_encode_fwd_out_data:267] [ERROR]: Error sending all output messages. Had to send 10, but sent 2
[ERROR:/jrtc/src/controller/jrtc_north_io_app.c:aa_channel_encode_fwd_out_data:268] [ERROR]: Error: Invalid argument
2025-06-17T12:37:15.172384+00:00 : {"timestamp": 1750163832776172544, "stream_index": "FAPI_UL_CONFIG", "ues": [{"cell_
```