### PR TITLE
Allow setting log levels in config yaml

### DIFF
--- a/jrtc_tests/unit_tests/logginglevel_test.c
+++ b/jrtc_tests/unit_tests/logginglevel_test.c
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
+    This test tests the logging level functionality in jrtc_logging.c
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "jrtc_logging.h"
+
+void
+test_logging_level()
+{
+    // all uppercase
+    assert(jrtc_get_logging_level("DEBUG") == JRTC_DEBUG_LEVEL);
+    assert(jrtc_get_logging_level("INFO") == JRTC_INFO_LEVEL);
+    assert(jrtc_get_logging_level("WARN") == JRTC_WARN_LEVEL);
+    assert(jrtc_get_logging_level("WARNING") == JRTC_WARN_LEVEL);
+    assert(jrtc_get_logging_level("ERROR") == JRTC_ERROR_LEVEL);
+    assert(jrtc_get_logging_level("CRITICAL") == JRTC_CRITICAL_LEVEL);
+    assert(jrtc_get_logging_level("FATAL") == JRTC_CRITICAL_LEVEL);
+    assert(jrtc_get_logging_level("UNKNOWN") == JRTC_DEBUG_LEVEL); // Default to DEBUG for unknown
+
+    // all lowercase
+    assert(jrtc_get_logging_level("debug") == JRTC_DEBUG_LEVEL);
+    assert(jrtc_get_logging_level("info") == JRTC_INFO_LEVEL);
+    assert(jrtc_get_logging_level("warn") == JRTC_WARN_LEVEL);
+    assert(jrtc_get_logging_level("warning") == JRTC_WARN_LEVEL);
+    assert(jrtc_get_logging_level("error") == JRTC_CRITICAL_LEVEL);
+    assert(jrtc_get_logging_level("critical") == JRTC_CRITICAL_LEVEL);
+    assert(jrtc_get_logging_level("fatal") == JRTC_CRITICAL_LEVEL);
+}
+
+void
+test_set_and_get_logging_level()
+{
+    // Set logging level to INFO
+    jrtc_set_logging_level(JRTC_INFO_LEVEL);
+    assert(jrtc_get_current_logging_level() == JRTC_INFO_LEVEL);
+
+    // Set logging level to DEBUG
+    jrtc_set_logging_level(JRTC_DEBUG_LEVEL);
+    assert(jrtc_get_current_logging_level() == JRTC_DEBUG_LEVEL);
+
+    // Set logging level to ERROR
+    jrtc_set_logging_level(JRTC_ERROR_LEVEL);
+    assert(jrtc_get_current_logging_level() == JRTC_ERROR_LEVEL);
+
+    // Set logging level to CRITICAL
+    jrtc_set_logging_level(JRTC_CRITICAL_LEVEL);
+    assert(jrtc_get_current_logging_level() == JRTC_CRITICAL_LEVEL);
+
+    // Set logging level to WARN
+    jrtc_set_logging_level(JRTC_WARN_LEVEL);
+    assert(jrtc_get_current_logging_level() == JRTC_WARN_LEVEL);
+}
+
+int
+main()
+{
+    printf("Running logging level tests...\n");
+    test_logging_level();
+    printf("Logging level tests passed.\n");
+    test_set_and_get_logging_level();
+    printf("Set and get logging level tests passed.\n");
+    return 0;
+}

--- a/jrtc_tests/unit_tests/logginglevel_test.c
+++ b/jrtc_tests/unit_tests/logginglevel_test.c
@@ -27,7 +27,7 @@ test_logging_level()
     assert(jrtc_get_logging_level("info") == JRTC_INFO_LEVEL);
     assert(jrtc_get_logging_level("warn") == JRTC_WARN_LEVEL);
     assert(jrtc_get_logging_level("warning") == JRTC_WARN_LEVEL);
-    assert(jrtc_get_logging_level("error") == JRTC_CRITICAL_LEVEL);
+    assert(jrtc_get_logging_level("error") == JRTC_ERROR_LEVEL);
     assert(jrtc_get_logging_level("critical") == JRTC_CRITICAL_LEVEL);
     assert(jrtc_get_logging_level("fatal") == JRTC_CRITICAL_LEVEL);
 }

--- a/src/controller/jrtc_config.c
+++ b/src/controller/jrtc_config.c
@@ -224,8 +224,6 @@ set_config_values(const char* filename, jrtc_config_t* config)
                 in_jbpf_io_config = 1;
             } else if (strcmp(key, "logging") == 0) {
                 in_logging = 1;
-            } else {
-                jrtc_logger(JRTC_ERROR, "Unknown mapping start: %s\n", key);
             }
             key[0] = '\0'; // Reset key
             break;

--- a/src/controller/jrtc_config.c
+++ b/src/controller/jrtc_config.c
@@ -11,6 +11,7 @@
 #include "jbpf_io_defs.h"
 #include "jrtc_config_int.h"
 #include "jrtc_config.h"
+#include "jbpf_logging.h"
 #include <yaml.h>
 
 char*
@@ -118,6 +119,7 @@ set_config_values(const char* filename, jrtc_config_t* config)
     int in_thread_config = 0;
     int in_sched_config = 0;
     int in_jbpf_io_config = 0;
+    int in_logging = 0;
 
     if (!yaml_parser_initialize(&parser)) {
         fprintf(stderr, "Failed to initialize YAML parser\n");
@@ -191,6 +193,19 @@ set_config_values(const char* filename, jrtc_config_t* config)
                     } else if (strcmp(key, "port") == 0) {
                         config->port = atoi(expanded_value);
                     }
+                } else if (in_logging) {
+                    if (strcmp(key, "jrtc_level") == 0) {
+                        jrtc_logging_level level = jrtc_get_logging_level(expanded_value);
+                        jrtc_logger(JRTC_INFO, "Setting logging level to %s (%d)\n", expanded_value, level);
+                        jrtc_set_logging_level(level);
+                    } else if (strcmp(key, "jbpf_level") == 0) {
+                        // Workaround/TODO: Currently jbpf does not have this API
+                        jbpf_logging_level level = (jbpf_logging_level)jrtc_get_logging_level(expanded_value);
+                        jrtc_logger(JRTC_INFO, "Setting JBPF logging level to %s (%d)\n", expanded_value, level);
+                        jbpf_set_logging_level(level);
+                    }
+                } else {
+                    jrtc_logger(JRTC_ERROR, "Unknown key: %s\n", key);
                 }
 
                 free(expanded_value);
@@ -207,6 +222,10 @@ set_config_values(const char* filename, jrtc_config_t* config)
                 in_sched_config = 1;
             } else if (strcmp(key, "jbpf_io_config") == 0) {
                 in_jbpf_io_config = 1;
+            } else if (strcmp(key, "logging") == 0) {
+                in_logging = 1;
+            } else {
+                jrtc_logger(JRTC_ERROR, "Unknown mapping start: %s\n", key);
             }
             key[0] = '\0'; // Reset key
             break;

--- a/src/controller/jrtc_config_sample.yaml
+++ b/src/controller/jrtc_config_sample.yaml
@@ -13,4 +13,4 @@ jbpf_io_config:
   jbpf_path: /tmp
 logging:
   jrtc_level: info
-  jbpf_level: warn
+  jbpf_level: debug

--- a/src/controller/jrtc_config_sample.yaml
+++ b/src/controller/jrtc_config_sample.yaml
@@ -11,3 +11,6 @@ jrtc_router_config:
 jbpf_io_config:
   jbpf_namespace: jbpf
   jbpf_path: /tmp
+logging:
+  jrtc_level: debug
+  jbpf_level: debug

--- a/src/controller/jrtc_config_sample.yaml
+++ b/src/controller/jrtc_config_sample.yaml
@@ -12,5 +12,5 @@ jbpf_io_config:
   jbpf_namespace: jbpf
   jbpf_path: /tmp
 logging:
-  jrtc_level: debug
-  jbpf_level: debug
+  jrtc_level: info
+  jbpf_level: warn

--- a/src/logger/jrtc_logging.c
+++ b/src/logger/jrtc_logging.c
@@ -8,7 +8,7 @@
 #include <time.h>
 #include <sys/time.h>
 
-static const char* STR[] = {FOREACH_LOG_LEVEL(GENERATE_STRING)};
+static const char* STR[] = {FOREACH_LOG_LEVEL_JRTC(GENERATE_STRING_JRTC)};
 
 void
 jrtc_default_va_logging(const char* domain, jrtc_logging_level level, const char* s, va_list arg)
@@ -29,7 +29,7 @@ jrtc_default_va_logging(const char* domain, jrtc_logging_level level, const char
         // Add timestamp and log level
         snprintf(output, LOGGING_BUFFER_LEN, "%s %s%s%s", timestamp, domain, STR[level], s);
 
-        FILE* where = level >= INFO ? stderr : stdout;
+        FILE* where = level >= JRTC_INFO_LEVEL ? stderr : stdout;
         vfprintf(where, output, arg);
         fflush(where);
     }
@@ -50,10 +50,10 @@ jrtc_default_logging(const char* domain, jrtc_logging_level level, const char* s
         strftime(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%S", tm_info);
         snprintf(timestamp + strlen(timestamp), sizeof(timestamp) - strlen(timestamp), ".%06ldZ", tv.tv_usec);
 
-        snprintf(output, LOGGING_BUFFER_LEN, "%s %s %s", timestamp, domain, s);
+        snprintf(output, LOGGING_BUFFER_LEN, "%s %s%s%s", timestamp, domain, STR[level], s);
         va_list ap;
         va_start(ap, s);
-        FILE* where = level >= INFO ? stderr : stdout;
+        FILE* where = level >= JRTC_INFO_LEVEL ? stderr : stdout;
         vfprintf(where, output, ap);
         va_end(ap);
         fflush(where);
@@ -78,6 +78,32 @@ jrtc_set_va_logging_function(jrtc_va_logger_function_type func)
     jrtc_va_logger = func;
 }
 
-jrtc_logging_level jrtc_logger_level = DEBUG;
+// case insensitive string comparison
+jrtc_logging_level
+jrtc_get_logging_level(const char* level_str)
+{
+    if (strcasecmp(level_str, "DEBUG") == 0) {
+        return JRTC_DEBUG_LEVEL;
+    } else if (strcasecmp(level_str, "INFO") == 0) {
+        return JRTC_INFO_LEVEL;
+    } else if (strcasecmp(level_str, "WARN") == 0 || strcasecmp(level_str, "WARNING") == 0) {
+        return JRTC_WARN_LEVEL;
+    } else if (strcasecmp(level_str, "ERROR") == 0) {
+        return JRTC_ERROR_LEVEL;
+    } else if (strcasecmp(level_str, "CRITICAL") == 0 || strcasecmp(level_str, "FATAL") == 0) {
+        return JRTC_CRITICAL_LEVEL;
+    }
+    // If no match found, return DEBUG as default
+    jrtc_logger(JRTC_ERROR, "Unknown logging level: %s. Defaulting to DEBUG.\n", level_str);
+    return JRTC_DEBUG_LEVEL;
+}
+
+jrtc_logging_level jrtc_logger_level = JRTC_DEBUG_LEVEL;
 jrtc_logger_function_type jrtc_logger = jrtc_default_logging;
 jrtc_va_logger_function_type jrtc_va_logger = jrtc_default_va_logging;
+
+jrtc_logging_level
+jrtc_get_current_logging_level(void)
+{
+    return jrtc_logger_level;
+}

--- a/src/logger/jrtc_logging.c
+++ b/src/logger/jrtc_logging.c
@@ -100,7 +100,7 @@ jrtc_get_logging_level(const char* level_str)
         return JRTC_CRITICAL_LEVEL;
     }
     // If no match found, return DEBUG as default
-    jrtc_logger(JRTC_ERROR, "Unknown logging level: %s. Defaulting to DEBUG.\n", level_str);
+    jrtc_logger(JRTC_WARN, "Unknown logging level: %s. Defaulting to DEBUG.\n", level_str);
     return JRTC_DEBUG_LEVEL;
 }
 

--- a/src/logger/jrtc_logging.c
+++ b/src/logger/jrtc_logging.c
@@ -8,7 +8,13 @@
 #include <time.h>
 #include <sys/time.h>
 
-static const char* STR[] = {FOREACH_LOG_LEVEL_JRTC(GENERATE_STRING_JRTC)};
+// remove the JRTC_ and _LEVEL suffix from the enum names
+static const char* STR[] = {
+    JRTC_LOG_WRAP("DEBUG"),
+    JRTC_LOG_WRAP("INFO"),
+    JRTC_LOG_WRAP("WARN"),
+    JRTC_LOG_WRAP("ERROR"),
+    JRTC_LOG_WRAP("CRITICAL")};
 
 void
 jrtc_default_va_logging(const char* domain, jrtc_logging_level level, const char* s, va_list arg)

--- a/src/logger/jrtc_logging.h
+++ b/src/logger/jrtc_logging.h
@@ -32,25 +32,25 @@ extern "C"
     "]: "
 
 // jrtc domain
-#define FOREACH_LOG_LEVEL(LOG_LEVEL) \
-    LOG_LEVEL(DEBUG)                 \
-    LOG_LEVEL(INFO)                  \
-    LOG_LEVEL(WARN)                  \
-    LOG_LEVEL(ERROR)                 \
-    LOG_LEVEL(CRITICAL)
+#define FOREACH_LOG_LEVEL_JRTC(LOG_LEVEL) \
+    LOG_LEVEL(JRTC_DEBUG_LEVEL)           \
+    LOG_LEVEL(JRTC_INFO_LEVEL)            \
+    LOG_LEVEL(JRTC_WARN_LEVEL)            \
+    LOG_LEVEL(JRTC_ERROR_LEVEL)           \
+    LOG_LEVEL(JRTC_CRITICAL_LEVEL)
 
 #define _STR(x) _VAL(x)
 #define _VAL(x) #x
 
     static inline const char*
-    get_file_name(const char* file)
+    get_file_name_jrtc(const char* file)
     {
         const char* p = strrchr(file, '/');
         return p ? p + 1 : file;
     }
 
     static inline char*
-    get_domain(const char* file)
+    get_domain_jrtc(const char* file)
     {
         const char* p = strstr(file, "src/");
         if (p) {
@@ -76,17 +76,17 @@ extern "C"
 
     // Function to generate the log prefix dynamically
     static inline const char*
-    get_log_prefix(const char* file, const char* func, int line, const char* level)
+    get_log_prefix_jrtc(const char* file, const char* func, int line, const char* level)
     {
         static char buffer[256];
-        char* domain = get_domain(file);
+        char* domain = get_domain_jrtc(file);
         // we may want to cache this, but for now we will just check the env var each time
         int JRTC_VERBOSE_LOGGING = getenv("JRTC_VERBOSE_LOGGING") != NULL;
         if (JRTC_VERBOSE_LOGGING) {
             if (domain) {
-                snprintf(buffer, sizeof(buffer), "[JRTC][%s]:%s:%s:%d", domain, get_file_name(file), func, line);
+                snprintf(buffer, sizeof(buffer), "[JRTC][%s]:%s:%s:%d", domain, get_file_name_jrtc(file), func, line);
             } else {
-                snprintf(buffer, sizeof(buffer), "[JRTC]:%s:%s:%d", get_file_name(file), func, line);
+                snprintf(buffer, sizeof(buffer), "[JRTC]:%s:%s:%d", get_file_name_jrtc(file), func, line);
             }
             free(domain);
             return buffer;
@@ -102,18 +102,18 @@ extern "C"
     }
 
 // Define macros using the helper function
-#define JRTC_CRITICAL get_log_prefix(__FILE__, __func__, __LINE__, "CRITICAL"), CRITICAL
-#define JRTC_ERROR get_log_prefix(__FILE__, __func__, __LINE__, "ERROR"), ERROR
-#define JRTC_WARN get_log_prefix(__FILE__, __func__, __LINE__, "WARN"), WARN
-#define JRTC_INFO get_log_prefix(__FILE__, __func__, __LINE__, "INFO"), INFO
-#define JRTC_DEBUG get_log_prefix(__FILE__, __func__, __LINE__, "DEBUG"), DEBUG
+#define JRTC_CRITICAL get_log_prefix_jrtc(__FILE__, __func__, __LINE__, "CRITICAL"), JRTC_CRITICAL_LEVEL
+#define JRTC_ERROR get_log_prefix_jrtc(__FILE__, __func__, __LINE__, "ERROR"), JRTC_ERROR_LEVEL
+#define JRTC_WARN get_log_prefix_jrtc(__FILE__, __func__, __LINE__, "WARN"), JRTC_WARN_LEVEL
+#define JRTC_INFO get_log_prefix_jrtc(__FILE__, __func__, __LINE__, "INFO"), JRTC_INFO_LEVEL
+#define JRTC_DEBUG get_log_prefix_jrtc(__FILE__, __func__, __LINE__, "DEBUG"), JRTC_DEBUG_LEVEL
 
-#define GENERATE_ENUM_LOG(ENUM) ENUM,
-#define GENERATE_STRING(STRING) JRTC_LOG_WRAP(#STRING),
+#define GENERATE_ENUM_LOG_JRTC(ENUM) ENUM,
+#define GENERATE_STRING_JRTC(STRING) JRTC_LOG_WRAP(#STRING),
 
     typedef enum
     {
-        FOREACH_LOG_LEVEL(GENERATE_ENUM_LOG)
+        FOREACH_LOG_LEVEL_JRTC(GENERATE_ENUM_LOG_JRTC)
     } jrtc_logging_level;
 
     /**
@@ -190,6 +190,23 @@ extern "C"
      */
     void
     jrtc_set_va_logging_function(jrtc_va_logger_function_type func);
+
+    /**
+     * @brief Get the logging level from a string, if the string is not recognized, it defaults to DEBUG
+     * @param level_str The logging level string (e.g., "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL")
+     * @ingroup logger
+     * @return The logging level
+     */
+    jrtc_logging_level
+    jrtc_get_logging_level(const char* level_str);
+
+    /**
+     * @brief Get current jrtc logging level
+     * @ingroup logger
+     * @return The current logging level
+     */
+    jrtc_logging_level
+    jrtc_get_current_logging_level(void);
 
 #pragma once
 #ifdef __cplusplus


### PR DESCRIPTION
This PR closes #76 

With this PR, you can now configure the logging levels for JRTC and JBPF in the config.yaml

```yaml
logging:
  jrtc_level: debug
  jbpf_level: info
```

level values: debug, info, warning, error, critical

![image](https://github.com/user-attachments/assets/fc33eba5-4598-4342-97df-e6fd86700b1c)


