### PR TITLE
Pass Device Addr (IP:Port) to JRTC Apps

### DIFF
--- a/src/controller/jrtc.h
+++ b/src/controller/jrtc.h
@@ -24,15 +24,16 @@ using atomic_bool = std::atomic<bool>;
  */
 #define MAX_APP_NAME_SIZE 16
 #define MAX_APP_PARAMS 255
+#define MAX_DEVICE_MAPPING 255
 #define MAX_APP_MODULES 255
 
 typedef pthread_t app_id_t;
 
-typedef struct _app_param_key_value_pair
+typedef struct _key_value_pair
 {
     char* key;
     char* val;
-} app_param_key_value_pair_t;
+} key_value_pair_t;
 
 /**
  * @brief The jrtc_app_env struct
@@ -60,7 +61,8 @@ struct jrtc_app_env
     atomic_bool app_exit;
     jrtc_sched_config_t sched_config;
     char* app_path;
-    app_param_key_value_pair_t params[MAX_APP_PARAMS];
+    key_value_pair_t params[MAX_APP_PARAMS];
+    key_value_pair_t device_mapping[MAX_DEVICE_MAPPING];
     char* app_modules[MAX_APP_MODULES];
     void* shared_python_state; // Pointer to shared Python state for multi-threaded apps
 };

--- a/src/controller/jrtc_int.c
+++ b/src/controller/jrtc_int.c
@@ -252,6 +252,12 @@ _is_app_loaded(load_app_request_t load_req)
             if (app_envs[i] != NULL && app_envs[i]->params[0].key != NULL &&
                 strcmp(app_envs[i]->params[0].key, load_req.params[0].key) == 0 && app_envs[i]->params[0].val != NULL &&
                 strcmp(app_envs[i]->params[0].val, load_req.params[0].val) == 0) {
+                jrtc_logger(
+                    JRTC_INFO,
+                    "Python App %s with params %s:%s is already loaded\n",
+                    load_req.app_name,
+                    load_req.params[0].key,
+                    load_req.params[0].val);
                 return true;
             }
         }
@@ -260,6 +266,11 @@ _is_app_loaded(load_app_request_t load_req)
         for (int i = 0; i < MAX_NUM_JRTC_APPS; i++) {
             if ((app_envs[i] != NULL) && (app_envs[i]->app_path != NULL) &&
                 (strcmp(app_envs[i]->app_path, load_req.app_path) == 0)) {
+                jrtc_logger(
+                    JRTC_INFO,
+                    "App %s with app_path %s is already loaded\n",
+                    load_req.app_name,
+                    load_req.app_path ? load_req.app_path : "(app_path is null)");
                 return true;
             }
         }

--- a/src/controller/jrtc_int.c
+++ b/src/controller/jrtc_int.c
@@ -308,7 +308,7 @@ load_app(load_app_request_t load_req)
     }
 
     // check if the app is already loaded
-    jrtc_logger(JRTC_DEBUG, "Checking if app1 %s is already loaded\n", load_req.app_name);
+    jrtc_logger(JRTC_DEBUG, "Checking if app %s is already loaded\n", load_req.app_name);
     if (_is_app_loaded(&load_req)) {
         jrtc_logger(
             JRTC_WARN,

--- a/src/controller/jrtc_int.c
+++ b/src/controller/jrtc_int.c
@@ -309,8 +309,10 @@ load_app(load_app_request_t load_req)
 
     app_env->app_handle = app_handle;
     app_env->app_exit = false;
+    app_env->app_path = strdup(load_req.app_path ? load_req.app_path : "unknown");
     app_env->io_queue_size = load_req.ioq_size;
     memset(app_env->params, 0, sizeof(app_env->params));
+    memset(app_env->device_mapping, 0, sizeof(app_env->device_mapping));
 
     for (int i = 0; i < MAX_APP_PARAMS; i++) {
         if (load_req.params[i].key != NULL) {
@@ -318,6 +320,15 @@ load_app(load_app_request_t load_req)
         }
         if (load_req.params[i].val != NULL) {
             app_env->params[i].val = strdup(load_req.params[i].val);
+        }
+    }
+
+    for (int i = 0; i < MAX_DEVICE_MAPPING; i++) {
+        if (load_req.device_mapping[i].key != NULL) {
+            app_env->device_mapping[i].key = strdup(load_req.device_mapping[i].key);
+        }
+        if (load_req.device_mapping[i].val != NULL) {
+            app_env->device_mapping[i].val = strdup(load_req.device_mapping[i].val);
         }
     }
 
@@ -377,6 +388,7 @@ unload_app(int app_id)
     jrtc_router_deregister_app(env->dapp_ctx);
     jrtc_logger(JRTC_INFO, "App %s shut down\n", env->app_name);
     free(env->app_name);
+    free(env->app_path);
     _jrtc_release_app_id(app_id);
     return 0;
 }
@@ -414,7 +426,9 @@ load_default_north_io_app()
 
     load_req_north_io.deadline_us = 0;
     load_req_north_io.app_name = strdup("north_io_app");
+    load_req_north_io.app_path = strdup(north_io_app_name);
     memset(load_req_north_io.params, 0, sizeof(load_req_north_io.params));
+    memset(load_req_north_io.device_mapping, 0, sizeof(load_req_north_io.device_mapping));
     memset(load_req_north_io.app_modules, 0, sizeof(load_req_north_io.app_modules));
 
     int res = load_app(load_req_north_io);
@@ -425,6 +439,7 @@ load_default_north_io_app()
     }
 
     free(load_req_north_io.app_name);
+    free(load_req_north_io.app_path);
     free(north_io_app_name);
     free(north_io_data);
     return res;

--- a/src/pythonapp_loader/jrtc_pythonapp_loader.c
+++ b/src/pythonapp_loader/jrtc_pythonapp_loader.c
@@ -309,6 +309,14 @@ jrtc_start_app(void* args)
     char* full_path = env_ctx->params[0].val;
     printf_and_flush("Python App Full path: %s\n", full_path);
 
+    for (int i = 0; i < MAX_DEVICE_MAPPING; i++) {
+        if (env_ctx->device_mapping[i].key == NULL) {
+            break;
+        }
+        printf_and_flush(
+            "Device Mapping %d: %s = %s\n", i, env_ctx->device_mapping[i].key, env_ctx->device_mapping[i].val);
+    }
+
     // Initialize Python interpreter once and create a new sub-interpreter per thread
     pthread_mutex_lock(&shared_python_state->python_lock);
     if (!shared_python_state->initialized) {

--- a/src/rest_api_lib/openapi.json
+++ b/src/rest_api_lib/openapi.json
@@ -234,6 +234,9 @@
           "app_params": {
             "type": "object"
           },
+          "device_mapping": {
+            "type": "object"
+          },          
           "app_modules": {
             "type": "array",
             "items": {

--- a/src/rest_api_lib/src/jrtc_rest_server.h
+++ b/src/rest_api_lib/src/jrtc_rest_server.h
@@ -30,7 +30,8 @@ typedef struct load_app_request
     uint32_t ioq_size;
     char* app_path;
     char* app_type;
-    app_param_key_value_pair_t params[MAX_APP_PARAMS];
+    key_value_pair_t params[MAX_APP_PARAMS];
+    key_value_pair_t device_mapping[MAX_DEVICE_MAPPING];
     char* app_modules[MAX_APP_MODULES];
 } load_app_request_t;
 

--- a/src/wrapper_apis/python/jrtc_wrapper_utils.py
+++ b/src/wrapper_apis/python/jrtc_wrapper_utils.py
@@ -23,6 +23,16 @@ def register_dll(path):
         raise ImportError(f"Failed to load {path} {e}")
         return None
 
+class KeyValuePair(ctypes.Structure):
+    _fields_ = [
+        ("key", ctypes.c_char_p),
+        ("value", ctypes.c_char_p),
+    ]
+
+MAX_APP_PARAMS = 255
+MAX_DEVICE_MAPPING = 255
+MAX_APP_MODULES = 255
+
 class JrtcAppEnv(ctypes.Structure):
     _fields_ = [
         ("app_name", ctypes.c_char_p),  # Define as c_char_p
@@ -33,8 +43,11 @@ class JrtcAppEnv(ctypes.Structure):
         ("io_queue_size", ctypes.c_uint),
         ("app_exit", ctypes.c_int),
         ("sched_config", jrtc_bindings.struct_jrtc_sched_config),
-        ("app_params",ctypes.c_char_p * 255),
-        ("app_modules", ctypes.c_char_p * 255),
+        ("app_path", ctypes.c_char_p),
+        ("params", KeyValuePair * MAX_APP_PARAMS),
+        ("device_mapping", KeyValuePair * MAX_DEVICE_MAPPING),
+        ("app_modules", ctypes.c_char_p * MAX_APP_MODULES),
+        ("shared_python_state", ctypes.c_void_p),
     ]
 
 def get_ctx_from_capsule(capsule):

--- a/test_apps/first_example_py/deployment.yaml
+++ b/test_apps/first_example_py/deployment.yaml
@@ -14,6 +14,7 @@ app:
     path: ${JRTC_PATH}/test_apps/first_example_py/first_example.py
     type: python
     port: 3001
+    deadline_us: 12345
     modules:
       - ${JRTC_PATH}/test_apps/jbpf_codelets/data_generator/generated_data.py
       - ${JRTC_PATH}/test_apps/jbpf_codelets/simple_input/simple_input.py

--- a/tools/jrtc-ctl/cmd/app/load/load.go
+++ b/tools/jrtc-ctl/cmd/app/load/load.go
@@ -38,6 +38,7 @@ type runOptions struct {
 	sharedLibraryPath string
 	appType           string
 	appParams         map[string]interface{}
+	deviceMapping     map[string]interface{}
 	appModules        []string
 }
 
@@ -116,7 +117,7 @@ func run(cmd *cobra.Command, opts *runOptions) error {
 			return err
 		}
 
-		req, err := jrtc.NewJrtcAppLoadRequest(opts.sharedLibraryPath, opts.appName, opts.ioqSize, opts.deadline, opts.period, opts.runtime, opts.appType, &opts.appModules, &opts.appParams)
+		req, err := jrtc.NewJrtcAppLoadRequest(opts.sharedLibraryPath, opts.appName, opts.ioqSize, opts.deadline, opts.period, opts.runtime, opts.appType, &opts.appModules, &opts.appParams, &opts.deviceMapping)
 		if err != nil {
 			return err
 		}

--- a/tools/jrtc-ctl/cmd/clicommon/config.go
+++ b/tools/jrtc-ctl/cmd/clicommon/config.go
@@ -89,6 +89,16 @@ func (c *JBPFConfig) GetDeviceMap() map[string]uint8 {
 	return out
 }
 
+// GetHostNameFromDeviceId returns the hostname for a given device ID
+func (c *JBPFConfig) GetHostNameFromDeviceId(id uint8) (string, error) {
+	for _, d := range c.Devices {
+		if d.ID == id {
+			return fmt.Sprintf("%s:%d", d.IP, d.Port), nil
+		}
+	}
+	return "", fmt.Errorf("device with ID %d not found", id)
+}
+
 // CLIConfig represents a configuration
 type CLIConfig struct {
 	Apps     []*App      `json:"app,omitempty"`

--- a/tools/jrtc-ctl/cmd/clicommon/config.go
+++ b/tools/jrtc-ctl/cmd/clicommon/config.go
@@ -64,7 +64,10 @@ type App struct {
 	AppType           string        `json:"type" jsonschema:"required"` // type is a string e.g. "c" or "python"
 	// params is a dictionary e.g. key value pairs
 	AppParams map[string]interface{} `json:"params,omitempty"`
-	// modules is a list of strings e.g. ["module1", "module2"]
+	// device_mapping is a dictionary e.g. key value pairs
+	// where key is the device ID and value is the device name
+	DeviceMapping map[string]interface{} `json:"-"`
+	// app_modules is a list of strings e.g. ["module1", "module2"]
 	AppModules []string `json:"modules,omitempty"`
 }
 
@@ -89,8 +92,8 @@ func (c *JBPFConfig) GetDeviceMap() map[string]uint8 {
 	return out
 }
 
-// GetHostNameFromDeviceId returns the hostname for a given device ID
-func (c *JBPFConfig) GetHostNameFromDeviceId(id uint8) (string, error) {
+// GetHostNameFromDeviceID returns the hostname for a given device ID
+func (c *JBPFConfig) GetHostNameFromDeviceID(id uint8) (string, error) {
 	for _, d := range c.Devices {
 		if d.ID == id {
 			return fmt.Sprintf("%s:%d", d.IP, d.Port), nil

--- a/tools/jrtc-ctl/cmd/clicommon/jbpf_config_test.go
+++ b/tools/jrtc-ctl/cmd/clicommon/jbpf_config_test.go
@@ -238,7 +238,7 @@ func TestGetHostNameFromDeviceId(t *testing.T) {
 	assert.Equal(t, "1.1.1.1:1234", host1)
 	assert.Equal(t, "2.2.2.2:5678", host2)
 	assert.Equal(t, "device with ID 3 not found", err3.Error())
-	assert.Nil(t, host3) // Should be nil since the ID does not exist
+	assert.Equal(t, "", host3) // Should be empty for non-existent ID
 }
 
 func TestGetDeviceMap(t *testing.T) {

--- a/tools/jrtc-ctl/cmd/clicommon/jbpf_config_test.go
+++ b/tools/jrtc-ctl/cmd/clicommon/jbpf_config_test.go
@@ -218,8 +218,8 @@ func createFileWithContent(name, content string) (string, func(), error) {
 	return f.Name(), cleanup, nil
 }
 
-// TestGetHostNameFromDeviceId tests the GetHostNameFromDeviceId method
-func TestGetHostNameFromDeviceId(t *testing.T) {
+// TestGetHostNameFromDeviceID tests the GetHostNameFromDeviceID method
+func TestGetHostNameFromDeviceID(t *testing.T) {
 	// Arrange - create a JBPFConfig with devices
 	cfg := &JBPFConfig{
 		Devices: []*JBPFDevice{
@@ -228,9 +228,9 @@ func TestGetHostNameFromDeviceId(t *testing.T) {
 		},
 	}
 	// Act - get hostnames for device IDs
-	host1, err1 := cfg.GetHostNameFromDeviceId(1)
-	host2, err2 := cfg.GetHostNameFromDeviceId(2)
-	host3, err3 := cfg.GetHostNameFromDeviceId(3) // Non-existent ID
+	host1, err1 := cfg.GetHostNameFromDeviceID(1)
+	host2, err2 := cfg.GetHostNameFromDeviceID(2)
+	host3, err3 := cfg.GetHostNameFromDeviceID(3) // Non-existent ID
 	require.Nil(t, err1)
 	require.Nil(t, err2)
 	require.NotNil(t, err3)

--- a/tools/jrtc-ctl/cmd/clicommon/jbpf_config_test.go
+++ b/tools/jrtc-ctl/cmd/clicommon/jbpf_config_test.go
@@ -217,3 +217,44 @@ func createFileWithContent(name, content string) (string, func(), error) {
 
 	return f.Name(), cleanup, nil
 }
+
+// TestGetHostNameFromDeviceId tests the GetHostNameFromDeviceId method
+func TestGetHostNameFromDeviceId(t *testing.T) {
+	// Arrange - create a JBPFConfig with devices
+	cfg := &JBPFConfig{
+		Devices: []*JBPFDevice{
+			{ID: 1, IP: "1.1.1.1", Port: 1234},
+			{ID: 2, IP: "2.2.2.2", Port: 5678},
+		},
+	}
+	// Act - get hostnames for device IDs
+	host1, err1 := cfg.GetHostNameFromDeviceId(1)
+	host2, err2 := cfg.GetHostNameFromDeviceId(2)
+	host3, err3 := cfg.GetHostNameFromDeviceId(3) // Non-existent ID
+	require.Nil(t, err1)
+	require.Nil(t, err2)
+	require.NotNil(t, err3)
+	// Assert - check the hostnames
+	assert.Equal(t, "1.1.1.1:1234", host1)
+	assert.Equal(t, "2.2.2.2:5678", host2)
+	assert.Equal(t, "device with ID 3 not found", err3.Error())
+	assert.Nil(t, host3) // Should be nil since the ID does not exist
+}
+
+func TestGetDeviceMap(t *testing.T) {
+	// Arrange - create a JBPFConfig with devices
+	cfg := &JBPFConfig{
+		Devices: []*JBPFDevice{
+			{ID: 1, IP: "1.1.1.1", Port: 1234},
+			{ID: 2, IP: "2.2.2.2", Port: 5678},
+		},
+	}
+	// Act - get the device map
+	deviceMap := cfg.GetDeviceMap()
+	// Assert - check the device map
+	expectedMap := map[string]uint8{
+		"1.1.1.1:1234": 1,
+		"2.2.2.2:5678": 2,
+	}
+	assert.Equal(t, expectedMap, deviceMap)
+}

--- a/tools/jrtc-ctl/services/jrt-controller/request.go
+++ b/tools/jrtc-ctl/services/jrt-controller/request.go
@@ -19,6 +19,7 @@ func NewJrtcAppLoadRequest(
 	appType string,
 	appModules *[]string,
 	appParams *map[string]interface{},
+	deviceMapping *map[string]interface{},
 ) (*JrtcAppLoadRequest, error) {
 	fi, err := os.Stat(sharedLibraryPath)
 	if err != nil {
@@ -35,16 +36,17 @@ func NewJrtcAppLoadRequest(
 	f.InitFromBytes(sharedObject, sharedLibraryPath)
 
 	return &JrtcAppLoadRequest{
-		App:        f,
-		AppName:    appName,
-		DeadlineUs: int32(deadline.Microseconds()),
-		IoqSize:    ioqSize,
-		PeriodUs:   int32(period.Microseconds()),
-		RuntimeUs:  int32(runtime.Microseconds()),
-		AppPath:    &sharedLibraryPath,
-		AppType:    &appType,
-		AppModules: appModules,
-		AppParams:  appParams,
+		App:           f,
+		AppName:       appName,
+		DeadlineUs:    int32(deadline.Microseconds()),
+		IoqSize:       ioqSize,
+		PeriodUs:      int32(period.Microseconds()),
+		RuntimeUs:     int32(runtime.Microseconds()),
+		AppPath:       &sharedLibraryPath,
+		AppType:       &appType,
+		AppModules:    appModules,
+		AppParams:     appParams,
+		DeviceMapping: deviceMapping,
 	}, nil
 }
 
@@ -56,20 +58,22 @@ func NewJrtcAppLoadRequestFromBytes(
 	appType string,
 	appModules *[]string,
 	appParams *map[string]interface{},
+	deviceMapping *map[string]interface{},
 ) (*JrtcAppLoadRequest, error) {
 	var f openapi_types.File
 	f.InitFromBytes(sharedLibraryCode, sharedLibraryPath)
 
 	return &JrtcAppLoadRequest{
-		App:        f,
-		AppName:    appName,
-		DeadlineUs: int32(deadline.Microseconds()),
-		IoqSize:    ioqSize,
-		PeriodUs:   int32(period.Microseconds()),
-		RuntimeUs:  int32(runtime.Microseconds()),
-		AppPath:    &sharedLibraryPath,
-		AppType:    &appType,
-		AppModules: appModules,
-		AppParams:  appParams,
+		App:           f,
+		AppName:       appName,
+		DeadlineUs:    int32(deadline.Microseconds()),
+		IoqSize:       ioqSize,
+		PeriodUs:      int32(period.Microseconds()),
+		RuntimeUs:     int32(runtime.Microseconds()),
+		AppPath:       &sharedLibraryPath,
+		AppType:       &appType,
+		AppModules:    appModules,
+		AppParams:     appParams,
+		DeviceMapping: deviceMapping,
 	}, nil
 }

--- a/tools/schemas/jrtc-ctl.schema.json
+++ b/tools/schemas/jrtc-ctl.schema.json
@@ -49,7 +49,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "modules is a list of strings e.g. [\"module1\", \"module2\"]"
+          "description": "app_modules is a list of strings e.g. [\"module1\", \"module2\"]"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This PR passes the ip:port/device-id from deployment yaml to the jrtc app env context. This PR also adds assertions in test_apps/first_example_py to make sure these values are passed correctly.

```python
def jrtc_start_app(capsule):
    env_ctx = get_ctx_from_capsule(capsule)
    if not env_ctx:
        raise ValueError("Failed to retrieve JrtcAppEnv from capsule")

    ## Extract necessary fields from env_ctx and make assertions
    app_name = env_ctx.app_name.decode("utf-8")
    io_queue_size = env_ctx.io_queue_size
    app_path = env_ctx.app_path.decode("utf-8")
    app_modules = env_ctx.app_modules
    app_params = env_ctx.params
    device_mapping = env_ctx.device_mapping

    ## assertions
    assert app_name == "app1", f"Unexpected app name: {app_name}"
    assert io_queue_size == 1000, f"Unexpected IO queue size: {io_queue_size}"
    assert app_path.split("/")[-1] == "libjrtc_pythonapp_loader.so", f"Unexpected app path: {app_path}"
    assert app_modules[0].decode("utf-8").split('/')[-1] == "generated_data.py", f"Unexpected first module: {app_modules[0]}"
    assert app_modules[1].decode("utf-8").split('/')[-1] == "simple_input.py", f"Unexpected second module: {app_modules[1]}"
    assert app_params[0].key.decode("utf-8") == "python", f"Unexpected app parameter key: {app_params[0].key}"
    assert app_params[0].value.decode("utf-8").split('/')[-1] == "first_example.py", f"Unexpected app parameter value: {app_params[0].value}"
    assert device_mapping[0].key.decode("utf-8") == "1", f"Unexpected device mapping key: {device_mapping[0].key}"
    assert device_mapping[0].value.decode("utf-8") == "127.0.0.1:8080", f"Unexpected device mapping value: {device_mapping[0].value}"
```

This PR refactors the function `_is_app_loaded()`
1. adding more debug messages, 
2. passing the parameter via Pointer to avoid copy
3. checking for NULL before calling strcmp

When app_type is "python", the python script is stored in parameters, thus this is used to check if the app has been loaded. For normal C/C++ app, the app is checked via the .so which is stored in app_path.
